### PR TITLE
feat: prevents revert on checktask

### DIFF
--- a/contracts/TasksRunner.sol
+++ b/contracts/TasksRunner.sol
@@ -245,7 +245,13 @@ contract TasksRunner is RoundManager {
         uint256 taskLength = tasks.length();
         for (uint256 i = 0; i < taskLength; i++) {
             ITask task = ITask(tasks.at(i));
-            if (task.checkTask()) {
+            bool isAvailable;
+            try task.checkTask() returns (bool result) {
+                isAvailable = result;
+            } catch {
+                isAvailable = false;
+            }
+            if (isAvailable) {
                 return true;
             }
         }
@@ -261,7 +267,13 @@ contract TasksRunner is RoundManager {
         address[] memory tasksAvailable = new address[](taskLength);
         for (uint256 i = 0; i < taskLength; i++) {
             ITask task = ITask(tasks.at(i));
-            if (task.checkTask()) {
+            bool isAvailable;
+            try task.checkTask() returns (bool result) {
+                isAvailable = result;
+            } catch {
+                isAvailable = false;
+            }
+            if (isAvailable) {
                 tasksAvailable[i] = address(task);
             }
         }

--- a/contracts/TasksRunner.sol
+++ b/contracts/TasksRunner.sol
@@ -38,6 +38,7 @@ contract TasksRunner is RoundManager {
         uint256 points,
         bool success
     );
+    event CheckTaskReverted(address task);
 
     constructor() public initializer {
         // Avoid leaving the implementation contract uninitialized.
@@ -205,6 +206,7 @@ contract TasksRunner is RoundManager {
             try task.checkTask() returns (bool result) {
                 shouldRun = result;
             } catch {
+                emit CheckTaskReverted(address(task));
                 shouldRun = false;
             }
 

--- a/contracts/testing_mocks/MockRevertingTask.sol
+++ b/contracts/testing_mocks/MockRevertingTask.sol
@@ -1,0 +1,14 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity 0.6.12;
+
+import {ITask} from "../interfaces/ITask.sol";
+
+contract MockRevertingTask is ITask {
+    function checkTask() external view override returns (bool) {
+        revert("checkTask reverted");
+    }
+
+    function runTask() external override returns (uint256) {
+        return 0;
+    }
+}

--- a/test/TasksRunner.js
+++ b/test/TasksRunner.js
@@ -106,4 +106,36 @@ contract('TasksRunner', (accounts) => {
         assert.equal(selectedOwners.length, 1);
         assert.equal(selectedOwners[0], ORACLE_OWNER);
     });
+
+    it('handles checkTask revert as unavailable for availability checks', async () => {
+        const MockTask = artifacts.require('MockTask');
+        const MockRevertingTask = artifacts.require('MockRevertingTask');
+        const okTask = await MockTask.new(true, 1);
+        const revertingTask = await MockRevertingTask.new();
+
+        const TasksRunner = artifacts.require('TasksRunner');
+        const tasksRunner = await helpers.deployProxySimple(TasksRunner);
+        await tasksRunner.initialize(
+            this.governor.addr,
+            TASKS_PAIR,
+            [revertingTask.address, okTask.address],
+            this.token.address,
+            5,
+            10,
+            60,
+            10,
+            this.oracleMgr.address,
+            this.registry,
+            1,
+            { from: GOVERNOR_OWNER },
+        );
+
+        const available = await tasksRunner.areTasksAvailable();
+        assert.equal(available, true);
+
+        const tasksAvailable = await tasksRunner.getTasksAvailable();
+        assert.equal(tasksAvailable.length, 2);
+        assert.equal(tasksAvailable[0], helpers.ADDRESS_ZERO);
+        assert.equal(tasksAvailable[1], okTask.address);
+    });
 });

--- a/test/TasksRunner.js
+++ b/test/TasksRunner.js
@@ -34,14 +34,16 @@ contract('TasksRunner', (accounts) => {
         Object.assign(this, contracts);
 
         const MockTask = artifacts.require('MockTask');
+        const MockRevertingTask = artifacts.require('MockRevertingTask');
         this.mockTask = await MockTask.new(true, 5);
+        this.revertingTask = await MockRevertingTask.new();
 
         const TasksRunner = artifacts.require('TasksRunner');
         this.tasksRunner = await helpers.deployProxySimple(TasksRunner);
         await this.tasksRunner.initialize(
             this.governor.addr,
             TASKS_PAIR,
-            [this.mockTask.address],
+            [this.revertingTask.address, this.mockTask.address],
             this.token.address,
             5,
             10,
@@ -100,6 +102,9 @@ contract('TasksRunner', (accounts) => {
             points: new BN(5),
             success: true,
         });
+        expectEvent(receipt, 'CheckTaskReverted', {
+            task: this.revertingTask.address,
+        });
 
         const roundInfo = await this.tasksRunner.getRoundInfo();
         const selectedOwners = roundInfo[4];
@@ -108,34 +113,12 @@ contract('TasksRunner', (accounts) => {
     });
 
     it('handles checkTask revert as unavailable for availability checks', async () => {
-        const MockTask = artifacts.require('MockTask');
-        const MockRevertingTask = artifacts.require('MockRevertingTask');
-        const okTask = await MockTask.new(true, 1);
-        const revertingTask = await MockRevertingTask.new();
-
-        const TasksRunner = artifacts.require('TasksRunner');
-        const tasksRunner = await helpers.deployProxySimple(TasksRunner);
-        await tasksRunner.initialize(
-            this.governor.addr,
-            TASKS_PAIR,
-            [revertingTask.address, okTask.address],
-            this.token.address,
-            5,
-            10,
-            60,
-            10,
-            this.oracleMgr.address,
-            this.registry,
-            1,
-            { from: GOVERNOR_OWNER },
-        );
-
-        const available = await tasksRunner.areTasksAvailable();
+        const available = await this.tasksRunner.areTasksAvailable();
         assert.equal(available, true);
 
-        const tasksAvailable = await tasksRunner.getTasksAvailable();
+        const tasksAvailable = await this.tasksRunner.getTasksAvailable();
         assert.equal(tasksAvailable.length, 2);
         assert.equal(tasksAvailable[0], helpers.ADDRESS_ZERO);
-        assert.equal(tasksAvailable[1], okTask.address);
+        assert.equal(tasksAvailable[1], this.mockTask.address);
     });
 });


### PR DESCRIPTION
This PR makes the areTasksAvailable and getTasksAvailable methods handle revert from checkTask methods, returning false instead.