### PR TITLE
fix: do not revert on checkTasks if the check fails for a task

### DIFF
--- a/contracts/TasksRunner.sol
+++ b/contracts/TasksRunner.sol
@@ -259,9 +259,6 @@ contract TasksRunner is RoundManager {
         uint256 taskLength = tasks.length();
         for (uint256 i = 0; i < taskLength; i++) {
             ITask task = ITask(tasks.at(i));
-            if (task.checkTask()) {
-                return true;
-            }
             try task.checkTask() returns (bool isAvailable) {
                 if (isAvailable) {
                     return true;

--- a/contracts/TasksRunner.sol
+++ b/contracts/TasksRunner.sol
@@ -262,6 +262,13 @@ contract TasksRunner is RoundManager {
             if (task.checkTask()) {
                 return true;
             }
+            try task.checkTask() returns (bool isAvailable) {
+                if (isAvailable) {
+                    return true;
+                }
+            } catch {
+                // If checkTask reverts, treat the task as unavailable and continue.
+            }
         }
         return false;
     }
@@ -275,8 +282,12 @@ contract TasksRunner is RoundManager {
         address[] memory tasksAvailable = new address[](taskLength);
         for (uint256 i = 0; i < taskLength; i++) {
             ITask task = ITask(tasks.at(i));
-            if (task.checkTask()) {
-                tasksAvailable[i] = address(task);
+            try task.checkTask() returns (bool isAvailable) {
+                if (isAvailable) {
+                    tasksAvailable[i] = address(task);
+                }
+            } catch {
+                // If checkTask reverts, treat the task as unavailable and continue.
             }
         }
         return tasksAvailable;


### PR DESCRIPTION
This PR makes it so the external calls to areTasksAvailable and getTasksAvailable do not revert if any checkTasks reverts. This could happen for example if a price provider becomes stale.
This also mimics the behaviour of the flags.

I think we've talked about this before, but at the moment I see no reason to have a different behaviour. If there is any, this PR should be replaced with a comment on those methods explaining why we allow them to revert.