### PR TITLE
Add forced price invalidation and forced revert modes to CoinPairPrice

### DIFF
--- a/contracts/CoinPairPrice.sol
+++ b/contracts/CoinPairPrice.sol
@@ -27,8 +27,7 @@ contract CoinPairPrice is RoundManager, IPriceProvider, IPriceProviderRegisterEn
         address votedOracle,
         uint256 blockNumber
     );
-    event ForcedInvalidationSet(address indexed setter, bool enabled);
-    event ForcedRevertSet(address indexed setter, bool enabled);
+    event ForcedPriceQueryModeSet(address indexed setter, PriceQueryMode mode);
 
     constructor() public initializer {
         // Avoid leaving the implementation contract uninitialized.
@@ -170,92 +169,50 @@ contract CoinPairPrice is RoundManager, IPriceProvider, IPriceProviderRegisterEn
         _;
     }
 
-    /// @notice Set forced price invalidation on or off.
-    /// @param _enabled True to force invalidation, false to restore normal validity rules.
-    function setForcedInvalidation(bool _enabled)
+    /// @notice Set forced price query mode.
+    /// @param _mode 0 = Ok, 1 = Invalid, 2 = Revert.
+    function setPriceQueryMode(PriceQueryMode _mode)
         external
-        onlyGovernanceOrWhitelisted(priceInvalidationWhitelistData)
+        onlyGovernanceOrWhitelisted(priceQueryModeWhitelistData)
     {
-        forcedInvalidation = _enabled;
-        emit ForcedInvalidationSet(msg.sender, _enabled);
+        priceQueryMode = _mode;
+        emit ForcedPriceQueryModeSet(msg.sender, _mode);
     }
 
-    /// @notice Add an address to the list allowed to toggle forced invalidation.
+    /// @notice Add an address to the list allowed to change the forced price query mode.
     /// @param _account Address to whitelist.
-    function addForcedInvalidationWhitelist(address _account)
+    function addPriceQueryModeWhitelist(address _account)
         external
         onlyAuthorizedChanger
     {
-        priceInvalidationWhitelistData._addToWhitelist(_account);
+        priceQueryModeWhitelistData._addToWhitelist(_account);
     }
 
-    /// @notice Remove an address from the list allowed to toggle forced invalidation.
+    /// @notice Remove an address from the list allowed to change the forced price query mode.
     /// @param _account Address to remove from whitelist.
-    function removeForcedInvalidationWhitelist(address _account)
+    function removePriceQueryModeWhitelist(address _account)
         external
         onlyAuthorizedChanger
     {
-        priceInvalidationWhitelistData._removeFromWhitelist(_account);
+        priceQueryModeWhitelistData._removeFromWhitelist(_account);
     }
 
-    /// @notice Set forced revert mode for price queries on or off.
-    /// @param _enabled True to force revert, false to restore normal query behavior.
-    function setForcedRevert(bool _enabled)
-        external
-        onlyGovernanceOrWhitelisted(priceRevertWhitelistData)
-    {
-        forcedRevert = _enabled;
-        emit ForcedRevertSet(msg.sender, _enabled);
+    /// @notice Return the current forced price query mode.
+    function getPriceQueryMode() external view returns (PriceQueryMode) {
+        return priceQueryMode;
     }
 
-    /// @notice Add an address to the list allowed to toggle forced revert.
-    /// @param _account Address to whitelist.
-    function addForcedRevertWhitelist(address _account)
-        external
-        onlyAuthorizedChanger
-    {
-        priceRevertWhitelistData._addToWhitelist(_account);
-    }
-
-    /// @notice Remove an address from the list allowed to toggle forced revert.
-    /// @param _account Address to remove from whitelist.
-    function removeForcedRevertWhitelist(address _account)
-        external
-        onlyAuthorizedChanger
-    {
-        priceRevertWhitelistData._removeFromWhitelist(_account);
-    }
-
-    /// @notice Return whether forced invalidation is active.
-    function getForcedInvalidation() external view returns (bool) {
-        return forcedInvalidation;
-    }
-
-    /// @notice Return whether forced revert is active.
-    function getForcedRevert() external view returns (bool) {
-        return forcedRevert;
-    }
-
-    /// @notice Check if an address is allowed to toggle forced invalidation.
-    function isForcedInvalidationWhitelisted(address _account)
+    /// @notice Check if an address is allowed to change the forced price query mode.
+    function isPriceQueryModeWhitelisted(address _account)
         external
         view
         returns (bool)
     {
-        return priceInvalidationWhitelistData._isWhitelisted(_account);
-    }
-
-    /// @notice Check if an address is allowed to toggle forced revert.
-    function isForcedRevertWhitelisted(address _account)
-        external
-        view
-        returns (bool)
-    {
-        return priceRevertWhitelistData._isWhitelisted(_account);
+        return priceQueryModeWhitelistData._isWhitelisted(_account);
     }
 
     function _requireNotForcedRevert() private view {
-        require(!forcedRevert, "Forced revert active");
+        require(priceQueryMode != PriceQueryMode.Revert, "Forced revert active");
     }
 
     // Legacy function compatible with old MOC Oracle.
@@ -331,7 +288,7 @@ contract CoinPairPrice is RoundManager, IPriceProvider, IPriceProviderRegisterEn
 
     /// @notice return true if the price is valid
     function _isValid() private view returns (bool) {
-        if (forcedInvalidation) {
+        if (priceQueryMode == PriceQueryMode.Invalid) {
             return false;
         }
         require(block.number >= lastPublicationBlock, "Wrong lastPublicationBlock");

--- a/contracts/CoinPairPrice.sol
+++ b/contracts/CoinPairPrice.sol
@@ -9,6 +9,7 @@ import {IPriceProvider} from "@moc/periphery/contracts/IPriceProvider.sol";
 import {IRegistry} from "@moc/periphery/contracts/IRegistry.sol";
 import {IPriceProviderRegisterEntry} from "@moc/periphery/contracts/IPriceProviderRegisterEntry.sol";
 import {SubscribedOraclesLib} from "./libs/SubscribedOraclesLib.sol";
+import {IterableWhitelistLib} from "./libs/IterableWhitelistLib.sol";
 import {OracleManager} from "./OracleManager.sol";
 import {RoundManager} from "./RoundManager.sol";
 
@@ -26,6 +27,8 @@ contract CoinPairPrice is RoundManager, IPriceProvider, IPriceProviderRegisterEn
         address votedOracle,
         uint256 blockNumber
     );
+    event ForcedInvalidationSet(address indexed setter, bool enabled);
+    event ForcedRevertSet(address indexed setter, bool enabled);
 
     constructor() public initializer {
         // Avoid leaving the implementation contract uninitialized.
@@ -157,6 +160,104 @@ contract CoinPairPrice is RoundManager, IPriceProvider, IPriceProviderRegisterEn
         emit EmergencyPricePublished(msg.sender, _price, msg.sender, lastPublicationBlock);
     }
 
+    modifier onlyGovernanceOrWhitelisted(
+        IterableWhitelistLib.IterableWhitelistData storage self
+    ) {
+        require(
+            governor.isAuthorizedChanger(msg.sender) || IterableWhitelistLib._isWhitelisted(self, msg.sender),
+            "Address is not authorized"
+        );
+        _;
+    }
+
+    /// @notice Set forced price invalidation on or off.
+    /// @param _enabled True to force invalidation, false to restore normal validity rules.
+    function setForcedInvalidation(bool _enabled)
+        external
+        onlyGovernanceOrWhitelisted(priceInvalidationWhitelistData)
+    {
+        forcedInvalidation = _enabled;
+        emit ForcedInvalidationSet(msg.sender, _enabled);
+    }
+
+    /// @notice Add an address to the list allowed to toggle forced invalidation.
+    /// @param _account Address to whitelist.
+    function addForcedInvalidationWhitelist(address _account)
+        external
+        onlyAuthorizedChanger
+    {
+        priceInvalidationWhitelistData._addToWhitelist(_account);
+    }
+
+    /// @notice Remove an address from the list allowed to toggle forced invalidation.
+    /// @param _account Address to remove from whitelist.
+    function removeForcedInvalidationWhitelist(address _account)
+        external
+        onlyAuthorizedChanger
+    {
+        priceInvalidationWhitelistData._removeFromWhitelist(_account);
+    }
+
+    /// @notice Set forced revert mode for price queries on or off.
+    /// @param _enabled True to force revert, false to restore normal query behavior.
+    function setForcedRevert(bool _enabled)
+        external
+        onlyGovernanceOrWhitelisted(priceRevertWhitelistData)
+    {
+        forcedRevert = _enabled;
+        emit ForcedRevertSet(msg.sender, _enabled);
+    }
+
+    /// @notice Add an address to the list allowed to toggle forced revert.
+    /// @param _account Address to whitelist.
+    function addForcedRevertWhitelist(address _account)
+        external
+        onlyAuthorizedChanger
+    {
+        priceRevertWhitelistData._addToWhitelist(_account);
+    }
+
+    /// @notice Remove an address from the list allowed to toggle forced revert.
+    /// @param _account Address to remove from whitelist.
+    function removeForcedRevertWhitelist(address _account)
+        external
+        onlyAuthorizedChanger
+    {
+        priceRevertWhitelistData._removeFromWhitelist(_account);
+    }
+
+    /// @notice Return whether forced invalidation is active.
+    function getForcedInvalidation() external view returns (bool) {
+        return forcedInvalidation;
+    }
+
+    /// @notice Return whether forced revert is active.
+    function getForcedRevert() external view returns (bool) {
+        return forcedRevert;
+    }
+
+    /// @notice Check if an address is allowed to toggle forced invalidation.
+    function isForcedInvalidationWhitelisted(address _account)
+        external
+        view
+        returns (bool)
+    {
+        return priceInvalidationWhitelistData._isWhitelisted(_account);
+    }
+
+    /// @notice Check if an address is allowed to toggle forced revert.
+    function isForcedRevertWhitelisted(address _account)
+        external
+        view
+        returns (bool)
+    {
+        return priceRevertWhitelistData._isWhitelisted(_account);
+    }
+
+    function _requireNotForcedRevert() private view {
+        require(!forcedRevert, "Forced revert active");
+    }
+
     // Legacy function compatible with old MOC Oracle.
     // returns a tuple (uint256, bool) that corresponds
     // to the price and if it is not expired.
@@ -167,6 +268,7 @@ contract CoinPairPrice is RoundManager, IPriceProvider, IPriceProviderRegisterEn
         whitelistedOrExternal(pricePeekWhitelistData)
         returns (bytes32, bool)
     {
+        _requireNotForcedRevert();
         return (bytes32(currentPrice), _isValid());
     }
 
@@ -178,11 +280,13 @@ contract CoinPairPrice is RoundManager, IPriceProvider, IPriceProviderRegisterEn
         whitelistedOrExternal(pricePeekWhitelistData)
         returns (uint256)
     {
+        _requireNotForcedRevert();
         return currentPrice;
     }
 
     // Return if the price is not expired.
     function getIsValid() external override view returns (bool) {
+        _requireNotForcedRevert();
         return _isValid();
     }
 
@@ -197,6 +301,7 @@ contract CoinPairPrice is RoundManager, IPriceProvider, IPriceProviderRegisterEn
             uint256
         )
     {
+        _requireNotForcedRevert();
         return (currentPrice, _isValid(), lastPublicationBlock);
     }
 
@@ -226,6 +331,9 @@ contract CoinPairPrice is RoundManager, IPriceProvider, IPriceProviderRegisterEn
 
     /// @notice return true if the price is valid
     function _isValid() private view returns (bool) {
+        if (forcedInvalidation) {
+            return false;
+        }
         require(block.number >= lastPublicationBlock, "Wrong lastPublicationBlock");
         return (block.number - lastPublicationBlock) < validPricePeriodInBlocks;
     }

--- a/contracts/CoinPairPrice.sol
+++ b/contracts/CoinPairPrice.sol
@@ -211,10 +211,6 @@ contract CoinPairPrice is RoundManager, IPriceProvider, IPriceProviderRegisterEn
         return priceQueryModeWhitelistData._isWhitelisted(_account);
     }
 
-    function _requireNotForcedRevert() private view {
-        require(priceQueryMode != PriceQueryMode.Revert, "Forced revert active");
-    }
-
     // Legacy function compatible with old MOC Oracle.
     // returns a tuple (uint256, bool) that corresponds
     // to the price and if it is not expired.
@@ -225,8 +221,7 @@ contract CoinPairPrice is RoundManager, IPriceProvider, IPriceProviderRegisterEn
         whitelistedOrExternal(pricePeekWhitelistData)
         returns (bytes32, bool)
     {
-        _requireNotForcedRevert();
-        return (bytes32(currentPrice), _isValid());
+        return (bytes32(currentPrice), _getPriceValidity());
     }
 
     /// @notice Return the current price
@@ -243,8 +238,7 @@ contract CoinPairPrice is RoundManager, IPriceProvider, IPriceProviderRegisterEn
 
     // Return if the price is not expired.
     function getIsValid() external override view returns (bool) {
-        _requireNotForcedRevert();
-        return _isValid();
+        return _getPriceValidity();
     }
 
     // Return the result of getPrice, getIsValid and getLastPublicationBlock at once.
@@ -258,8 +252,7 @@ contract CoinPairPrice is RoundManager, IPriceProvider, IPriceProviderRegisterEn
             uint256
         )
     {
-        _requireNotForcedRevert();
-        return (currentPrice, _isValid(), lastPublicationBlock);
+        return (currentPrice, _getPriceValidity(), lastPublicationBlock);
     }
 
     // Public variable
@@ -287,12 +280,22 @@ contract CoinPairPrice is RoundManager, IPriceProvider, IPriceProviderRegisterEn
     // ----------------------------------------------------------------------------------------------------------------
 
     /// @notice return true if the price is valid
-    function _isValid() private view returns (bool) {
-        if (priceQueryMode == PriceQueryMode.Invalid) {
+    function _requireNotForcedRevert() private view {
+        if (priceQueryMode == PriceQueryMode.Revert) {
+            revert("Forced revert active");
+        }
+    }
+
+    function _getPriceValidity() private view returns (bool) {
+        PriceQueryMode mode = priceQueryMode;
+        if (mode == PriceQueryMode.Ok) {
+            require(block.number >= lastPublicationBlock, "Wrong lastPublicationBlock");
+            return (block.number - lastPublicationBlock) < validPricePeriodInBlocks;
+        }
+        if (mode == PriceQueryMode.Invalid) {
             return false;
         }
-        require(block.number >= lastPublicationBlock, "Wrong lastPublicationBlock");
-        return (block.number - lastPublicationBlock) < validPricePeriodInBlocks;
+        revert("Forced revert active");
     }
 
     // @notice publish a price, called only after verification.

--- a/contracts/CoinPairPrice.sol
+++ b/contracts/CoinPairPrice.sol
@@ -211,6 +211,17 @@ contract CoinPairPrice is RoundManager, IPriceProvider, IPriceProviderRegisterEn
         return priceQueryModeWhitelistData._isWhitelisted(_account);
     }
 
+    /// @notice Return the number of addresses allowed to change the forced price query mode.
+    function getPriceQueryModeWhitelistLen() external view returns (uint256) {
+        return priceQueryModeWhitelistData._getWhiteListLen();
+    }
+
+    /// @notice Return the address allowed to change the forced price query mode at index.
+    /// @param _idx Index to query.
+    function getPriceQueryModeWhitelistAtIndex(uint256 _idx) external view returns (address) {
+        return priceQueryModeWhitelistData._getWhiteListAtIndex(_idx);
+    }
+
     // Legacy function compatible with old MOC Oracle.
     // returns a tuple (uint256, bool) that corresponds
     // to the price and if it is not expired.

--- a/contracts/CoinPairPrice.sol
+++ b/contracts/CoinPairPrice.sol
@@ -222,6 +222,28 @@ contract CoinPairPrice is RoundManager, IPriceProvider, IPriceProviderRegisterEn
         return priceQueryModeWhitelistData._getWhiteListAtIndex(_idx);
     }
 
+    /// @notice Return the number of addresses allowed to query price peek data.
+    function getPricePeekWhitelistLen() external view returns (uint256) {
+        return pricePeekWhitelistData._getWhiteListLen();
+    }
+
+    /// @notice Return the address allowed to query price peek data at index.
+    /// @param _idx Index to query.
+    function getPricePeekWhitelistAtIndex(uint256 _idx) external view returns (address) {
+        return pricePeekWhitelistData._getWhiteListAtIndex(_idx);
+    }
+
+    /// @notice Return the number of addresses allowed to emergency publish.
+    function getEmergencyPublishWhitelistLen() external view returns (uint256) {
+        return emergencyPublishWhitelistData._getWhiteListLen();
+    }
+
+    /// @notice Return the address allowed to emergency publish at index.
+    /// @param _idx Index to query.
+    function getEmergencyPublishWhitelistAtIndex(uint256 _idx) external view returns (address) {
+        return emergencyPublishWhitelistData._getWhiteListAtIndex(_idx);
+    }
+
     // Legacy function compatible with old MOC Oracle.
     // returns a tuple (uint256, bool) that corresponds
     // to the price and if it is not expired.

--- a/contracts/CoinPairPriceStorage.sol
+++ b/contracts/CoinPairPriceStorage.sol
@@ -87,7 +87,7 @@ contract CoinPairPriceStorage is Initializable, Governed, IIterableWhitelist {
     constructor() internal {}
 
     // Reserved storage space to allow for layout changes in the future.
-    uint256[47] private ______gap;
+    uint256[44] private ______gap;
 
     /**
       @notice Modifier that protects the function

--- a/contracts/CoinPairPriceStorage.sol
+++ b/contracts/CoinPairPriceStorage.sol
@@ -69,17 +69,17 @@ contract CoinPairPriceStorage is Initializable, Governed, IIterableWhitelist {
     // Last round number where each oracle owner signed a valid publication/execution.
     mapping(address => uint256) internal lastSignedRoundByOracle;
 
-    // Forced invalidation of price information.
-    bool internal forcedInvalidation;
+    enum PriceQueryMode {
+        Ok,
+        Invalid,
+        Revert
+    }
 
-    // Whitelist of addresses allowed to toggle forced invalidation.
-    IterableWhitelistLib.IterableWhitelistData internal priceInvalidationWhitelistData;
+    // Forced price query mode. 0 = Ok, 1 = Invalid, 2 = Revert.
+    PriceQueryMode internal priceQueryMode;
 
-    // Forced revert mode when querying price information.
-    bool internal forcedRevert;
-
-    // Whitelist of addresses allowed to toggle forced revert.
-    IterableWhitelistLib.IterableWhitelistData internal priceRevertWhitelistData;
+    // Whitelist of addresses allowed to change the forced price query mode.
+    IterableWhitelistLib.IterableWhitelistData internal priceQueryModeWhitelistData;
 
     // Empty internal constructor, to prevent people from mistakenly deploying
     // an instance of this contract, which should be used via inheritance.

--- a/contracts/CoinPairPriceStorage.sol
+++ b/contracts/CoinPairPriceStorage.sol
@@ -69,6 +69,18 @@ contract CoinPairPriceStorage is Initializable, Governed, IIterableWhitelist {
     // Last round number where each oracle owner signed a valid publication/execution.
     mapping(address => uint256) internal lastSignedRoundByOracle;
 
+    // Forced invalidation of price information.
+    bool internal forcedInvalidation;
+
+    // Whitelist of addresses allowed to toggle forced invalidation.
+    IterableWhitelistLib.IterableWhitelistData internal priceInvalidationWhitelistData;
+
+    // Forced revert mode when querying price information.
+    bool internal forcedRevert;
+
+    // Whitelist of addresses allowed to toggle forced revert.
+    IterableWhitelistLib.IterableWhitelistData internal priceRevertWhitelistData;
+
     // Empty internal constructor, to prevent people from mistakenly deploying
     // an instance of this contract, which should be used via inheritance.
     // solhint-disable-next-line no-empty-blocks

--- a/test/CoinPairPrice.js
+++ b/test/CoinPairPrice.js
@@ -35,6 +35,25 @@ contract('CoinPairPrice', async (accounts) => {
         expect(roundLockPeriod).to.be.bignumber.equal(new BN(60));
     });
 
+    it('Should expose price query mode whitelist entries', async () => {
+        expect(await this.coinPairPrice.getPriceQueryModeWhitelistLen()).to.be.bignumber.equal(
+            new BN(0),
+        );
+
+        await this.coinPairPrice.addPriceQueryModeWhitelist(accounts[6], { from: accounts[8] });
+        await this.coinPairPrice.addPriceQueryModeWhitelist(accounts[7], { from: accounts[8] });
+
+        expect(await this.coinPairPrice.getPriceQueryModeWhitelistLen()).to.be.bignumber.equal(
+            new BN(2),
+        );
+        expect(await this.coinPairPrice.getPriceQueryModeWhitelistAtIndex(0)).to.equal(accounts[6]);
+        expect(await this.coinPairPrice.getPriceQueryModeWhitelistAtIndex(1)).to.equal(accounts[7]);
+        await expectRevert(
+            this.coinPairPrice.getPriceQueryModeWhitelistAtIndex(2),
+            'index out of bounds',
+        );
+    });
+
     const oracleData = [
         {
             name: 'oracle-a.io',


### PR DESCRIPTION
## Summary

- Added a unified forced query mode in `CoinPairPrice` for price responses
- Designed the feature with a single `PriceQueryMode` enum:
  - `Ok` — normal behavior
  - `Invalid` — query functions return price data but mark it invalid
  - `Revert` — query functions force a revert
- Updated all price query methods to honor this mode:
  - `peek()`
  - `getPrice()`
  - `getIsValid()`
  - `getPriceInfo()`
- Added a single governance-controlled whitelist for managing mode changes
- Added setters to enable/disable the forced query mode through governance or whitelisted addresses
- The forced mode starts disabled by default, preserving normal operation unless explicitly changed